### PR TITLE
Revert "UploadJSON: Add CORS bypass heading"

### DIFF
--- a/pkg/almanack/filestore.go
+++ b/pkg/almanack/filestore.go
@@ -48,8 +48,7 @@ func UploadJSON(ctx context.Context, is aws.BlobStore, filepath, cachecontrol st
 	if err != nil {
 		return err
 	}
-	h := make(http.Header, 3)
-	h.Set("Access-Control-Allow-Origin", "*")
+	h := make(http.Header, 2)
 	h.Set("Content-Type", "application/json")
 	h.Set("Cache-Control", cachecontrol)
 	return is.WriteFile(ctx, filepath, h, b)


### PR DESCRIPTION
This reverts commit ed6abaae3ab07febc554ad835e0464a016fc6518.

Access control needs to be done at the CDN level.