### PR TITLE
ThumbnailImage: require AP permission checkbox before download

### DIFF
--- a/src/api/ap-agreed.js
+++ b/src/api/ap-agreed.js
@@ -1,0 +1,3 @@
+import { ref } from "vue";
+
+export const apAgreed = ref(false);

--- a/src/components/ThumbnailImage.vue
+++ b/src/components/ThumbnailImage.vue
@@ -1,5 +1,7 @@
 <script setup>
-import { computed, ref } from "vue";
+import { computed } from "vue";
+
+import { apAgreed } from "@/api/ap-agreed.js";
 
 const props = defineProps({
   imageUrl: { type: String, default: "" },
@@ -10,7 +12,6 @@ const props = defineProps({
 });
 
 const isAP = computed(() => /\bAP\b/.test(props.credit));
-const apAgreed = ref(false);
 const canDownload = computed(() => !isAP.value || apAgreed.value);
 </script>
 

--- a/src/components/ThumbnailImage.vue
+++ b/src/components/ThumbnailImage.vue
@@ -1,11 +1,16 @@
 <script setup>
-defineProps({
+import { computed, ref } from "vue";
+
+const props = defineProps({
   imageUrl: { type: String, default: "" },
   downloadUrl: { type: String, default: "" },
   description: { type: String, default: "" },
   credit: { type: String, default: "" },
   caption: { type: String, default: "" },
 });
+
+const isAP = computed(() => /\bAP\b/.test(props.credit));
+const apAgreed = ref(false);
 </script>
 
 <template>
@@ -21,8 +26,15 @@ defineProps({
       </a>
     </div>
     <figcaption>
+      <template v-if="isAP">
+        <label class="checkbox has-margin-bottom is-flex is-align-items-center" style="gap: 0.5rem">
+          <input type="checkbox" v-model="apAgreed" />
+          I agree that my organization has permission to use AP images
+        </label>
+      </template>
       <p class="has-margin-bottom">
         <a
+          v-if="!isAP || apAgreed"
           :href="downloadUrl"
           class="button is-danger has-text-weight-semibold"
           target="_blank"
@@ -35,6 +47,19 @@ defineProps({
           </span>
           <span>Download image</span>
         </a>
+        <button
+          v-else
+          class="button is-danger has-text-weight-semibold"
+          type="button"
+          disabled
+        >
+          <span class="icon">
+            <font-awesome-icon
+              :icon="['fas', 'file-download']"
+            ></font-awesome-icon>
+          </span>
+          <span>Download image</span>
+        </button>
       </p>
       <template v-if="description">
         <p class="has-margin-bottom-thin">

--- a/src/components/ThumbnailImage.vue
+++ b/src/components/ThumbnailImage.vue
@@ -11,34 +11,41 @@ const props = defineProps({
 
 const isAP = computed(() => /\bAP\b/.test(props.credit));
 const apAgreed = ref(false);
+const canDownload = computed(() => !isAP.value || apAgreed.value);
 </script>
 
 <template>
   <figure>
     <div class="has-margin-bottom">
-      <a
+      <component
+        :is="canDownload ? 'a' : 'span'"
         :href="downloadUrl"
         class="is-inline-flex max-256 has-background-grey-lighter"
         target="_blank"
         download
       >
         <img class="max-256" :src="imageUrl" width="256" height="192" />
-      </a>
+      </component>
     </div>
     <figcaption>
       <template v-if="isAP">
-        <label class="checkbox has-margin-bottom is-flex is-align-items-center" style="gap: 0.5rem">
+        <label
+          class="checkbox has-margin-bottom is-flex is-align-items-center"
+          style="gap: 0.5rem"
+        >
           <input type="checkbox" v-model="apAgreed" />
-          I agree that my organization has permission to use AP images
+          I affirm that my organization has permission to use AP images
         </label>
       </template>
       <p class="has-margin-bottom">
-        <a
-          v-if="!isAP || apAgreed"
+        <component
+          :is="canDownload ? 'a' : 'button'"
           :href="downloadUrl"
           class="button is-danger has-text-weight-semibold"
           target="_blank"
-          download
+          :download="canDownload || null"
+          :type="canDownload ? null : 'button'"
+          :disabled="!canDownload || null"
         >
           <span class="icon">
             <font-awesome-icon
@@ -46,20 +53,7 @@ const apAgreed = ref(false);
             ></font-awesome-icon>
           </span>
           <span>Download image</span>
-        </a>
-        <button
-          v-else
-          class="button is-danger has-text-weight-semibold"
-          type="button"
-          disabled
-        >
-          <span class="icon">
-            <font-awesome-icon
-              :icon="['fas', 'file-download']"
-            ></font-awesome-icon>
-          </span>
-          <span>Download image</span>
-        </button>
+        </component>
       </p>
       <template v-if="description">
         <p class="has-margin-bottom-thin">


### PR DESCRIPTION
If an image credit matches `/\bAP\b/`, show a checkbox 'I agree that my organization has permission to use AP images' and disable the download button until it is checked.