### PR TITLE
utils/wait.ts: consolidate wait/debounce/throttle utilities

### DIFF
--- a/src/api/gdocs.js
+++ b/src/api/gdocs.js
@@ -1,10 +1,5 @@
 import { getGDocsDoc, postGDocsDoc, get, post } from "./client-v2";
-
-function wait(milliseconds) {
-  return new Promise((resolve) => {
-    window.setTimeout(resolve, milliseconds);
-  });
-}
+import { wait } from "@/utils/wait.ts";
 
 export async function processGDocsDoc(externalGDocsID) {
   // Create job

--- a/src/api/service-util.js
+++ b/src/api/service-util.js
@@ -1,6 +1,6 @@
 import { computed, reactive, toRefs, watch } from "vue";
 
-import { useThrottleToggle } from "@/utils/throttle.js";
+import { useThrottleToggle } from "@/utils/wait.ts";
 
 export function makeState() {
   const apiState = reactive({

--- a/src/components/CopyTextarea.vue
+++ b/src/components/CopyTextarea.vue
@@ -1,4 +1,6 @@
 <script>
+import { wait, seconds } from "@/utils/wait.ts";
+
 export default {
   name: "CopyTextarea",
   props: {
@@ -31,9 +33,7 @@ export default {
       await this.$nextTick();
       if (document.execCommand("copy")) {
         this.$emit("copied", true);
-        window.setTimeout(() => {
-          this.$emit("copied", false);
-        }, 5000); // 5s
+        wait(seconds(5)).then(() => this.$emit("copied", false));
       }
     },
   },

--- a/src/components/EmailComposer.vue
+++ b/src/components/EmailComposer.vue
@@ -1,5 +1,6 @@
 <script>
 import { computed, reactive, toRefs } from "vue";
+import { wait, seconds } from "@/utils/wait.ts";
 import { post, sendMessage } from "@/api/client-v2.js";
 
 export default {
@@ -44,9 +45,8 @@ export default {
           emailStatus.isSending = false;
           if (emailStatus.error) return;
           emailStatus.hasSent = true;
-          window.setTimeout(() => {
-            emailStatus.hasSent = false;
-          }, 5000);
+          await wait(seconds(5));
+          emailStatus.hasSent = false;
         }
       },
       discard() {

--- a/src/components/PageFinder.vue
+++ b/src/components/PageFinder.vue
@@ -25,10 +25,10 @@ export default {
     },
   },
   watch: {
-    query: debounce(function (val) {
+    query: debounce(300, function (val) {
       this.loading = true;
       this.fetch(val);
-    }, 300),
+    }),
   },
   created() {
     this.loading = true;

--- a/src/components/PageFinder.vue
+++ b/src/components/PageFinder.vue
@@ -2,6 +2,7 @@
 import draggable from "vuedraggable";
 
 import { get, listPagesByFTS } from "@/api/client-v2.js";
+import { debounce } from "@/utils/wait.ts";
 
 import { Page } from "@/api/spotlightpa-page.js";
 
@@ -15,7 +16,6 @@ export default {
       rawPages: [],
       error: null,
       loading: false,
-      timeout: null,
       currentRequest: 0,
     };
   },
@@ -25,13 +25,10 @@ export default {
     },
   },
   watch: {
-    async query(val) {
+    query: debounce(function (val) {
       this.loading = true;
-      window.clearTimeout(this.timeout);
-      this.timeout = window.setTimeout(() => {
-        this.fetch(val);
-      }, 300);
-    },
+      this.fetch(val);
+    }, 300),
   },
   created() {
     this.loading = true;

--- a/src/components/PageFinder.vue
+++ b/src/components/PageFinder.vue
@@ -25,7 +25,7 @@ export default {
     },
   },
   watch: {
-    query: debounce(300, function (val) {
+    query: debounce(300 /* ms */, function (val) {
       this.loading = true;
       this.fetch(val);
     }),

--- a/src/components/PageFinder.vue
+++ b/src/components/PageFinder.vue
@@ -25,15 +25,12 @@ export default {
     },
   },
   created() {
-    this.$watch(
-      "query",
-      debounce(300 /* ms */, (val) => {
-        this.loading = true;
-        this.fetch(val);
-      })
-    );
-    this.loading = true;
-    this.fetch(this.query);
+    const load = (val) => {
+      this.loading = true;
+      this.fetch(val);
+    };
+    load(this.query);
+    this.$watch("query", debounce(300 /* ms */, load));
   },
   methods: {
     async fetch(query) {

--- a/src/components/PageFinder.vue
+++ b/src/components/PageFinder.vue
@@ -24,13 +24,14 @@ export default {
       return this.rawPages.map((data) => new Page(data));
     },
   },
-  watch: {
-    query: debounce(300 /* ms */, (val) => {
-      this.loading = true;
-      this.fetch(val);
-    }),
-  },
   created() {
+    this.$watch(
+      "query",
+      debounce(300 /* ms */, (val) => {
+        this.loading = true;
+        this.fetch(val);
+      })
+    );
     this.loading = true;
     this.fetch(this.query);
   },

--- a/src/components/PageFinder.vue
+++ b/src/components/PageFinder.vue
@@ -25,7 +25,7 @@ export default {
     },
   },
   watch: {
-    query: debounce(300 /* ms */, function (val) {
+    query: debounce(300 /* ms */, (val) => {
       this.loading = true;
       this.fetch(val);
     }),

--- a/src/components/SpinnerProgress.vue
+++ b/src/components/SpinnerProgress.vue
@@ -8,9 +8,9 @@ const props = defineProps({
 });
 
 const debouncedLoading = ref(true);
-const setLoadingTrue = makeDebounce(() => {
+const setLoadingTrue = makeDebounce(props.debounce ?? 0, () => {
   debouncedLoading.value = true;
-}, props.debounce ?? 0);
+});
 watch(
   () => props.isLoading,
   (val) => {

--- a/src/components/SpinnerProgress.vue
+++ b/src/components/SpinnerProgress.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, watch } from "vue";
+import { debounce as makeDebounce } from "@/utils/wait.ts";
 
 const props = defineProps({
   isLoading: Boolean,
@@ -7,16 +8,15 @@ const props = defineProps({
 });
 
 const debouncedLoading = ref(true);
-let timeout = null;
+const setLoadingTrue = makeDebounce(() => {
+  debouncedLoading.value = true;
+}, props.debounce ?? 0);
 watch(
   () => props.isLoading,
   (val) => {
     if (!props.debounce || !val) return;
-    window.clearTimeout(timeout);
     debouncedLoading.value = false;
-    timeout = window.setTimeout(() => {
-      debouncedLoading.value = true;
-    }, props.debounce);
+    setLoadingTrue();
   }
 );
 </script>

--- a/src/components/ViewArticleRedirect.vue
+++ b/src/components/ViewArticleRedirect.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from "vue";
+import { wait, seconds } from "@/utils/wait.ts";
 import { useRouter, useRoute } from "vue-router";
 
 import { get, getSharedArticle } from "@/api/client-v2.js";
@@ -13,9 +14,9 @@ const props = defineProps({
 
 const isLoading = ref(false);
 const isLoadingDebounced = ref(false);
-window.setTimeout(() => {
+wait(seconds(0.5)).then(() => {
   isLoadingDebounced.value = true;
-}, 500);
+});
 const error = ref(null);
 
 async function load() {

--- a/src/components/ViewArticleRedirect.vue
+++ b/src/components/ViewArticleRedirect.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from "vue";
-import { wait, seconds } from "@/utils/wait.ts";
+import { wait } from "@/utils/wait.ts";
 import { useRouter, useRoute } from "vue-router";
 
 import { get, getSharedArticle } from "@/api/client-v2.js";
@@ -14,7 +14,7 @@ const props = defineProps({
 
 const isLoading = ref(false);
 const isLoadingDebounced = ref(false);
-wait(seconds(0.5)).then(() => {
+wait(500 /* ms */).then(() => {
   isLoadingDebounced.value = true;
 });
 const error = ref(null);

--- a/src/components/ViewImageUploader.vue
+++ b/src/components/ViewImageUploader.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, watch } from "vue";
-import { debounce } from "@/utils/wait.ts";
+import { debounce, seconds } from "@/utils/wait.ts";
 
 import { get, post, listImages, postImageUpdate } from "@/api/client-v2.js";
 import { makeState, watchAPI } from "@/api/service-util.js";
@@ -124,7 +124,7 @@ function updateIsLicensed(image) {
 const rawQuery = ref("");
 const applyQuery = debounce((val) => {
   query.value = val;
-}, 1000);
+}, seconds(1));
 watch(rawQuery, applyQuery);
 </script>
 

--- a/src/components/ViewImageUploader.vue
+++ b/src/components/ViewImageUploader.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, watch } from "vue";
+import { debounce } from "@/utils/wait.ts";
 
 import { get, post, listImages, postImageUpdate } from "@/api/client-v2.js";
 import { makeState, watchAPI } from "@/api/service-util.js";
@@ -121,13 +122,10 @@ function updateIsLicensed(image) {
 }
 
 const rawQuery = ref("");
-let timeout = null;
-watch(rawQuery, (val) => {
-  window.clearTimeout(timeout);
-  timeout = window.setTimeout(() => {
-    query.value = val;
-  }, 1000);
-});
+const applyQuery = debounce((val) => {
+  query.value = val;
+}, 1000);
+watch(rawQuery, applyQuery);
 </script>
 
 <template>

--- a/src/components/ViewImageUploader.vue
+++ b/src/components/ViewImageUploader.vue
@@ -124,9 +124,9 @@ function updateIsLicensed(image) {
 const rawQuery = ref("");
 watch(
   rawQuery,
-  debounce((val) => {
+  debounce(seconds(1), (val) => {
     query.value = val;
-  }, seconds(1))
+  })
 );
 </script>
 

--- a/src/components/ViewImageUploader.vue
+++ b/src/components/ViewImageUploader.vue
@@ -122,10 +122,12 @@ function updateIsLicensed(image) {
 }
 
 const rawQuery = ref("");
-const applyQuery = debounce((val) => {
-  query.value = val;
-}, seconds(1));
-watch(rawQuery, applyQuery);
+watch(
+  rawQuery,
+  debounce((val) => {
+    query.value = val;
+  }, seconds(1))
+);
 </script>
 
 <template>

--- a/src/utils/throttle.js
+++ b/src/utils/throttle.js
@@ -1,2 +1,0 @@
-// Re-exported from utils/wait.ts for backwards compatibility.
-export { useThrottleToggle } from "./wait.ts";

--- a/src/utils/throttle.js
+++ b/src/utils/throttle.js
@@ -1,23 +1,2 @@
-import { computed, ref, toRef, watch } from "vue";
-
-export function useThrottleToggle(
-  watchedRef,
-  { prop = "", timeout = 1000 } = {}
-) {
-  const watched = prop ? toRef(watchedRef, prop) : watchedRef;
-
-  const recentlyChanged = ref(false);
-  watch(
-    watched,
-    (val) => {
-      if (val) {
-        recentlyChanged.value = true;
-        window.setTimeout(() => {
-          recentlyChanged.value = false;
-        }, timeout);
-      }
-    },
-    { immediate: true }
-  );
-  return computed(() => watchedRef.value || recentlyChanged.value);
-}
+// Re-exported from utils/wait.ts for backwards compatibility.
+export { useThrottleToggle } from "./wait.ts";

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -1,0 +1,46 @@
+import { computed, ref, watch, type Ref } from "vue";
+
+// seconds converts a duration in seconds to milliseconds.
+export const seconds = (s: number): number => 1000 * s;
+
+// wait returns a Promise that resolves after `ms` milliseconds.
+export function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+// debounce wraps `fn` so it is only called after `ms` milliseconds of
+// inactivity. Each new call resets the timer.
+export function debounce<T extends unknown[]>(
+  fn: (...args: T) => void,
+  ms: number
+): (...args: T) => void {
+  let timer: ReturnType<typeof window.setTimeout> | null = null;
+  return function (this: unknown, ...args: T) {
+    window.clearTimeout(timer ?? undefined);
+    timer = window.setTimeout(() => fn.apply(this, args), ms);
+  };
+}
+
+// useThrottleToggle keeps a ref true for at least `timeout` ms after the
+// watched ref last became true. Useful for preventing loading-spinner flicker.
+export function useThrottleToggle(
+  watchedRef: Ref<boolean>,
+  { timeout = 1000 } = {}
+) {
+  const recentlyChanged = ref(false);
+  watch(
+    watchedRef,
+    (val) => {
+      if (val) {
+        recentlyChanged.value = true;
+        window.setTimeout(() => {
+          recentlyChanged.value = false;
+        }, timeout);
+      }
+    },
+    { immediate: true }
+  );
+  return computed(() => watchedRef.value || recentlyChanged.value);
+}

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -31,13 +31,16 @@ export function useThrottleToggle<T>(
   { timeout = 1000 } = {}
 ) {
   const recentlyChanged = ref(false);
+  let timer: ReturnType<typeof window.setTimeout> | null = null;
   watch(
     watchedRef,
     (val) => {
       if (val) {
+        window.clearTimeout(timer ?? undefined);
         recentlyChanged.value = true;
-        window.setTimeout(() => {
+        timer = window.setTimeout(() => {
           recentlyChanged.value = false;
+          timer = null;
         }, timeout);
       }
     },

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -17,7 +17,7 @@ export function wait(ms: number): Promise<void> {
 export function debounce<A extends unknown[]>(
   ms: number,
   fn: (...args: A) => void
-): (...args: A) => void {
+) {
   let timer: Timer | undefined;
   return (...args: A) => {
     window.clearTimeout(timer);

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -1,7 +1,7 @@
 import { computed, ref, watch, type Ref } from "vue";
 
 // seconds converts a duration in seconds to milliseconds.
-export const seconds = (s: number): number => 1000 * s;
+export const seconds = (s: number): number => 1_000 * s;
 
 // wait returns a Promise that resolves after `ms` milliseconds.
 export function wait(ms: number): Promise<void> {
@@ -12,21 +12,22 @@ export function wait(ms: number): Promise<void> {
 
 // debounce wraps `fn` so it is only called after `ms` milliseconds of
 // inactivity. Each new call resets the timer.
-export function debounce<T extends unknown[]>(
-  fn: (...args: T) => void,
+export function debounce<A extends unknown[]>(
+  fn: (...args: A) => void,
   ms: number
-): (...args: T) => void {
+): (...args: A) => void {
   let timer: ReturnType<typeof window.setTimeout> | null = null;
-  return function (this: unknown, ...args: T) {
+  return function (this: unknown, ...args: A) {
     window.clearTimeout(timer ?? undefined);
     timer = window.setTimeout(() => fn.apply(this, args), ms);
   };
 }
 
-// useThrottleToggle keeps a ref true for at least `timeout` ms after the
-// watched ref last became true. Useful for preventing loading-spinner flicker.
-export function useThrottleToggle(
-  watchedRef: Ref<boolean>,
+// useThrottleToggle keeps a ref true
+// for at least `timeout` ms after the watched ref last became truthy.
+// Useful for preventing loading-spinner flicker.
+export function useThrottleToggle<T>(
+  watchedRef: Ref<T>,
   { timeout = 1000 } = {}
 ) {
   const recentlyChanged = ref(false);

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -19,9 +19,9 @@ export function debounce<A extends unknown[]>(
   fn: (...args: A) => void
 ): (...args: A) => void {
   let timer: Timer | undefined;
-  return function (this: unknown, ...args: A) {
+  return (...args: A) => {
     window.clearTimeout(timer);
-    timer = window.setTimeout(() => fn.apply(this, args), ms);
+    timer = window.setTimeout(() => fn(...args), ms);
   };
 }
 

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -13,8 +13,8 @@ export function wait(ms: number): Promise<void> {
 // debounce wraps `fn` so it is only called after `ms` milliseconds of
 // inactivity. Each new call resets the timer.
 export function debounce<A extends unknown[]>(
-  fn: (...args: A) => void,
-  ms: number
+  ms: number,
+  fn: (...args: A) => void
 ): (...args: A) => void {
   let timer: ReturnType<typeof window.setTimeout> | null = null;
   return function (this: unknown, ...args: A) {

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -18,9 +18,9 @@ export function debounce<A extends unknown[]>(
   ms: number,
   fn: (...args: A) => void
 ): (...args: A) => void {
-  let timer: Timer | null = null;
+  let timer: Timer | undefined;
   return function (this: unknown, ...args: A) {
-    window.clearTimeout(timer ?? undefined);
+    window.clearTimeout(timer);
     timer = window.setTimeout(() => fn.apply(this, args), ms);
   };
 }
@@ -33,16 +33,16 @@ export function useThrottleToggle<T>(
   { timeout = 1000 } = {}
 ) {
   const recentlyChanged = ref(false);
-  let timer: Timer | null = null;
+  let timer: Timer | undefined;
   watch(
     watchedRef,
     (val) => {
       if (val) {
-        window.clearTimeout(timer ?? undefined);
+        window.clearTimeout(timer);
         recentlyChanged.value = true;
         timer = window.setTimeout(() => {
           recentlyChanged.value = false;
-          timer = null;
+          timer = undefined;
         }, timeout);
       }
     },

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -1,5 +1,8 @@
 import { computed, ref, watch, type Ref } from "vue";
 
+// Timer is the return type of window.setTimeout.
+type Timer = ReturnType<typeof window.setTimeout>;
+
 // seconds converts a duration in seconds to milliseconds.
 export const seconds = (s: number): number => 1_000 * s;
 
@@ -16,7 +19,7 @@ export function debounce<A extends unknown[]>(
   ms: number,
   fn: (...args: A) => void
 ): (...args: A) => void {
-  let timer: ReturnType<typeof window.setTimeout> | null = null;
+  let timer: Timer | null = null;
   return function (this: unknown, ...args: A) {
     window.clearTimeout(timer ?? undefined);
     timer = window.setTimeout(() => fn.apply(this, args), ms);
@@ -31,7 +34,7 @@ export function useThrottleToggle<T>(
   { timeout = 1000 } = {}
 ) {
   const recentlyChanged = ref(false);
-  let timer: ReturnType<typeof window.setTimeout> | null = null;
+  let timer: Timer | null = null;
   watch(
     watchedRef,
     (val) => {

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -1,6 +1,5 @@
 import { computed, ref, watch, type Ref } from "vue";
 
-// Timer is the return type of window.setTimeout.
 type Timer = ReturnType<typeof window.setTimeout>;
 
 // seconds converts a duration in seconds to milliseconds.

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -42,7 +42,6 @@ export function useThrottleToggle<T>(
         recentlyChanged.value = true;
         timer = window.setTimeout(() => {
           recentlyChanged.value = false;
-          timer = undefined;
         }, timeout);
       }
     },


### PR DESCRIPTION
Add src/utils/wait.ts (TypeScript) with three exports:
- seconds(s): unit helper, converts seconds to milliseconds
- wait(ms): promise-based delay
- debounce(fn, ms): typed debounce wrapper

Move useThrottleToggle from throttle.js into wait.ts; keep throttle.js as a one-line re-export shim for backwards compatibility.

Move the local wait() from gdocs.js to use the shared util.

Replace all bare window.setTimeout patterns in components:
- CopyTextarea, EmailComposer, ViewArticleRedirect: wait(seconds(...))
- ViewImageUploader, PageFinder, SpinnerProgress: debounce(...)