### PR TITLE
fix: correct typos in user-facing strings

### DIFF
--- a/internal/db/map.go
+++ b/internal/db/map.go
@@ -26,7 +26,7 @@ func (m *Map) Scan(value any) error {
 	}
 	buf, ok := value.([]byte)
 	if !ok {
-		return fmt.Errorf("canot parse %T to bytes", value)
+		return fmt.Errorf("cannot parse %T to bytes", value)
 	}
 	if err := json.Unmarshal(buf, &dbMap); err != nil {
 		return err

--- a/internal/services/arc/arc-schema.go
+++ b/internal/services/arc/arc-schema.go
@@ -73,7 +73,7 @@ func (item *FeedItem) Scan(value any) error {
 	}
 	buf, ok := value.([]byte)
 	if !ok {
-		return errors.New("canot parse to bytes")
+		return errors.New("cannot parse to bytes")
 	}
 	if err := json.Unmarshal(buf, &newItem); err != nil {
 		return err

--- a/src/components/ViewAuthorizedDomains.vue
+++ b/src/components/ViewAuthorizedDomains.vue
@@ -149,7 +149,7 @@ export default {
       </form>
     </div>
     <div class="mt-6">
-      <h2 class="title">Preauthorized email adddresses</h2>
+      <h2 class="title">Preauthorized email addresses</h2>
       <SpinnerProgress :is-loading="address.isLoading.value"></SpinnerProgress>
 
       <div class="field is-grouped is-grouped-multiline">


### PR DESCRIPTION
Fixes three misspellings, all of which reach users rather than sitting in comments:

- `src/components/ViewAuthorizedDomains.vue` — the heading rendered as
  "Preauthorized email adddresses" (three `d`s).
- `internal/db/map.go` — error text `"canot parse %T to bytes"`.
- `internal/services/arc/arc-schema.go` — error text `"canot parse to bytes"`.

Text only; no behaviour change.
