### PR TITLE
promotion: make id a ref, set in init like all other fields

### DIFF
--- a/src/api/promotion.ts
+++ b/src/api/promotion.ts
@@ -18,7 +18,7 @@ export interface PromotionJSON {
 type PromotionUpdateJSON = Required<Omit<PromotionJSON, "updated_at">>;
 
 export interface Promotion {
-  id: number | null;
+  id: Ref<number | null>;
   updatedAt: Ref<Date | null>;
   name: Ref<string>;
   description: Ref<string>;
@@ -34,7 +34,7 @@ export interface Promotion {
 }
 
 export function makePromotion(initial: PromotionJSON = {}): Promotion {
-  const id = initial.id ?? null;
+  const id = ref<number | null>(null);
   const updatedAt = ref<Date | null>(null);
   const name = ref("");
   const description = ref("");
@@ -47,6 +47,7 @@ export function makePromotion(initial: PromotionJSON = {}): Promotion {
   const imageUrls = ref<string[]>([]);
 
   function init(src: PromotionJSON = {}): void {
+    id.value = src.id ?? null;
     updatedAt.value = maybeDate(src, "updated_at");
     name.value = src.name ?? "";
     description.value = src.description ?? "";
@@ -63,7 +64,7 @@ export function makePromotion(initial: PromotionJSON = {}): Promotion {
 
   function toJSON(): PromotionUpdateJSON {
     return {
-      id,
+      id: id.value,
       name: name.value,
       description: description.value,
       width: width.value,

--- a/src/components/PromotionListRow.vue
+++ b/src/components/PromotionListRow.vue
@@ -46,7 +46,7 @@ async function remove() {
   if (!confirm(`Delete "${props.modelValue.name || "this promotion"}"?`)) {
     return;
   }
-  await deleteExec(() => post(deletePromotion, { id: promo.id }));
+  await deleteExec(() => post(deletePromotion, { id: promo.id.value }));
   if (!deleteStateRefs.error.value) {
     emit("delete");
   }

--- a/src/components/SiteParamsPromoSelector.vue
+++ b/src/components/SiteParamsPromoSelector.vue
@@ -67,7 +67,7 @@ const hasMore = computedProp("next_page", (v) => !!v);
 
     <div
       v-for="promo in promotions"
-      :key="promo.id"
+      :key="promo.id.value"
       class="is-flex is-align-items-center is-justify-content-space-between py-2"
       style="border-bottom: 1px solid #dbdbdb"
     >


### PR DESCRIPTION
Previously id was set once at construction time from the initial value and never updated on subsequent init() calls. This meant that after a watch-driven init() (e.g. in PromotionListRow), the id would be stale or null if the initial makePromotion() call had no data.

- Change Promotion.id from plain number|null to Ref<number|null>
- Set id.value inside init() alongside all other fields
- Update callers: promo.id → promo.id.value in PromotionListRow (delete call) and SiteParamsPromoSelector (:key binding)